### PR TITLE
fix(auth): make JWT subject a string and cast identity to int on read

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,32 +1,51 @@
+from datetime import timedelta
+import os
 from flask import Flask, jsonify
 from flask_sqlalchemy import SQLAlchemy
 from flask_bcrypt import Bcrypt
 from flask_jwt_extended import JWTManager
+from dotenv import load_dotenv
+
+# local imports
 from models import db, bcrypt
 
-app = Flask(__name__)
+load_dotenv()  # loads .env if present
 
-# Config
-app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///dev.db"
-app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-app.config["JWT_SECRET_KEY"] = "super-secret-key"  # 🔑 later use env var
+def create_app():
+    app = Flask(__name__)
 
-# Init extensions
-db.init_app(app)
-bcrypt.init_app(app)
-jwt = JWTManager(app)
+    # Config
+    app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv("DATABASE_URL", "sqlite:///dev.db")
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    app.config["JWT_SECRET_KEY"] = os.getenv("JWT_SECRET_KEY", "dev-secret-change-me")
+    app.config["JWT_ACCESS_TOKEN_EXPIRES"] = timedelta(minutes=25)
+    app.config["JWT_REFRESH_TOKEN_EXPIRES"] = timedelta(days=7)
 
-@app.get("/api/health")
-def health():
-    return jsonify({"status": "ok"}), 200
+    # Init
+    db.init_app(app)
+    bcrypt.init_app(app)
+    JWTManager(app)
 
-@app.get("/")
-def home():
-    return jsonify({"message": "Freelance Flow API running"}), 200
+    # Routes
+    @app.get("/api/health")
+    def health():
+        return jsonify({"status": "ok"}), 200
 
-# DB create_all
-with app.app_context():
-    db.create_all()
+    @app.get("/")
+    def home():
+        return jsonify({"message": "Freelance Flow API running"}), 200
+
+    # Blueprints
+    from routes.auth import auth_bp
+    app.register_blueprint(auth_bp, url_prefix="/api/auth")
+
+    # Create tables
+    with app.app_context():
+        db.create_all()
+
+    return app
+
+app = create_app()
 
 if __name__ == "__main__":
     app.run(port=5555, debug=True)

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -1,0 +1,72 @@
+from flask import Blueprint, request, jsonify
+from flask_jwt_extended import (
+    create_access_token, create_refresh_token,
+    jwt_required, get_jwt_identity
+)
+from models import db, bcrypt, User
+
+auth_bp = Blueprint("auth", __name__)
+
+@auth_bp.post("/register")
+def register():
+    data = request.get_json() or {}
+    email = (data.get("email") or "").strip().lower()
+    password = data.get("password") or ""
+
+    if not email or not password:
+        return jsonify(error={"message": "email and password required"}), 400
+
+    if User.query.filter_by(email=email).first():
+        return jsonify(error={"message": "email already registered"}), 409
+
+    user = User(email=email)
+    user.set_password(password)
+    db.session.add(user)
+    db.session.commit()
+
+    access = create_access_token(identity=user.id)
+    refresh = create_refresh_token(identity=user.id)
+
+    return jsonify(
+        user={"id": user.id, "email": user.email},
+        access_token=access,
+        refresh_token=refresh
+    ), 201
+
+@auth_bp.post("/login")
+def login():
+    data = request.get_json() or {}
+    email = (data.get("email") or "").strip().lower()
+    password = data.get("password") or ""
+
+    user = User.query.filter_by(email=email).first()
+    if not user or not user.check_password(password):
+        return jsonify(error={"message": "invalid credentials"}), 401
+
+    access = create_access_token(identity=str(user.id))
+    refresh = create_refresh_token(identity=str(user.id))
+
+
+    return jsonify(
+        user={"id": user.id, "email": user.email},
+        access_token=access,
+        refresh_token=refresh
+    ), 200
+
+@auth_bp.post("/refresh")
+@jwt_required(refresh=True)
+def refresh():
+    user_id = get_jwt_identity()  
+    access = create_access_token(identity=user_id)  
+    return jsonify(access_token=access), 200
+
+
+@auth_bp.get("/me")
+@jwt_required()
+def me():
+    user_id = int(get_jwt_identity())
+    user = User.query.get(user_id)
+    if not user:
+        return jsonify(error={"message": "user not found"}), 404
+    return jsonify(user={"id": user.id, "email": user.email}), 200
+


### PR DESCRIPTION
- Updated auth route to store JWT subject as string
- Cast identity back to int when fetching user
- Fixes "Subject must be a string" error on /me
